### PR TITLE
Fix: Fixed renaming of namespaces in config files

### DIFF
--- a/PV260_Project/BusinessLayer/BusinessLayer.csproj
+++ b/PV260_Project/BusinessLayer/BusinessLayer.csproj
@@ -4,7 +4,6 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <RootNamespace>BL</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/PV260_Project/BusinessLayer/DataLoading/CsvFileLoader.cs
+++ b/PV260_Project/BusinessLayer/DataLoading/CsvFileLoader.cs
@@ -1,31 +1,31 @@
 ﻿using System.Globalization;
-using BL.Exceptions;
-using BL.Extensions;
+using BusinessLayer.Extensions;
+using BusinessLayer.Exceptions;
 using CsvHelper;
 using CsvHelper.Configuration;
 using CsvHelper.Configuration.Attributes;
-using DAL.Models;
+using DataLayer.Models;
 
-namespace BL.DataLoading;
+namespace BusinessLayer.DataLoading;
 
 public class CsvLine
 {
     [Name("date")]
-    public string Date { get; set; }
+    public string? Date { get; set; }
     [Name("fund")]
-    public string Fund { get; set; }
+    public string? Fund { get; set; }
     [Name("company")]
-    public string Company { get; set; }
+    public string? Company { get; set; }
     [Name("ticker")]
-    public string Ticker { get; set; }
+    public string? Ticker { get; set; }
     [Name("cusip")]
-    public string Cusip { get; set; }
+    public string? Cusip { get; set; }
     [Name("shares")]
-    public string Shares { get; set; }
+    public string? Shares { get; set; }
     [Name("market value ($)")]
-    public string MarketValue { get; set; }
+    public string? MarketValue { get; set; }
     [Name("weight (%)")]
-    public string Weight { get; set; }
+    public string? Weight { get; set; }
 }
 
 public class CsvFileLoader : IDataLoader
@@ -67,11 +67,11 @@ public class CsvFileLoader : IDataLoader
             holding.Company = csvLine.Company;
             holding.Ticker = csvLine.Ticker;
             holding.Cusip = csvLine.Cusip;
-            holding.Shares = long.Parse(csvLine.Shares.Replace(",", ""));
-            csvLine.MarketValue.GetCurrencyAndValue().Deconstruct(out var currency, out var value);
+            holding.Shares = long.Parse(csvLine.Shares!.Replace(",", ""));
+            csvLine.MarketValue!.GetCurrencyAndValue().Deconstruct(out var currency, out var value);
             holding.Currency = currency;
             holding.MarketValue = value;
-            holding.Weight = double.Parse(csvLine.Weight.Remove(csvLine.Weight.Length - 1), CultureInfo.InvariantCulture);
+            holding.Weight = double.Parse(csvLine.Weight!.Remove(csvLine.Weight.Length - 1), CultureInfo.InvariantCulture);
             file.Holdings.Add(holding);
         }
 

--- a/PV260_Project/BusinessLayer/DataLoading/CsvFileLoader.cs
+++ b/PV260_Project/BusinessLayer/DataLoading/CsvFileLoader.cs
@@ -11,21 +11,21 @@ namespace BusinessLayer.DataLoading;
 public class CsvLine
 {
     [Name("date")]
-    public string? Date { get; set; }
+    public string Date { get; set; }
     [Name("fund")]
-    public string? Fund { get; set; }
+    public string Fund { get; set; }
     [Name("company")]
-    public string? Company { get; set; }
+    public string Company { get; set; }
     [Name("ticker")]
-    public string? Ticker { get; set; }
+    public string Ticker { get; set; }
     [Name("cusip")]
-    public string? Cusip { get; set; }
+    public string Cusip { get; set; }
     [Name("shares")]
-    public string? Shares { get; set; }
+    public string Shares { get; set; }
     [Name("market value ($)")]
-    public string? MarketValue { get; set; }
+    public string MarketValue { get; set; }
     [Name("weight (%)")]
-    public string? Weight { get; set; }
+    public string Weight { get; set; }
 }
 
 public class CsvFileLoader : IDataLoader

--- a/PV260_Project/BusinessLayer/DataLoading/IDataLoader.cs
+++ b/PV260_Project/BusinessLayer/DataLoading/IDataLoader.cs
@@ -1,6 +1,6 @@
-using DAL.Models;
+using DataLayer.Models;
 
-namespace BL.DataLoading;
+namespace BusinessLayer.DataLoading;
 
 public interface IDataLoader
 {

--- a/PV260_Project/BusinessLayer/DiffComputing/DiffComputer.cs
+++ b/PV260_Project/BusinessLayer/DiffComputing/DiffComputer.cs
@@ -1,6 +1,6 @@
-﻿using DAL.Models;
+﻿using DataLayer.Models;
 
-namespace BL.DiffComputing;
+namespace BusinessLayer.DiffComputing;
 
 public class DiffComputer : IDiffComputer
 {
@@ -11,9 +11,9 @@ public class DiffComputer : IDiffComputer
 
         foreach (var holding in first.Holdings)
         {
-            if (diff.Any(hc => hc.Holding.Company.Equals(holding.Company)))
+            if (diff.Any(hc => hc.Holding!.Company!.Equals(holding.Company)))
                 continue;
-            var secondHolding = second.Holdings.First(h => h.Company.Equals(holding.Company));
+            var secondHolding = second.Holdings.First(h => h.Company!.Equals(holding.Company));
 
             diff.Add(new HoldingChanges
             {

--- a/PV260_Project/BusinessLayer/DiffComputing/IDiffComputer.cs
+++ b/PV260_Project/BusinessLayer/DiffComputing/IDiffComputer.cs
@@ -1,6 +1,6 @@
-using DAL.Models;
+using DataLayer.Models;
 
-namespace BL.DiffComputing;
+namespace BusinessLayer.DiffComputing;
 
 public interface IDiffComputer
 {

--- a/PV260_Project/BusinessLayer/Exceptions/DataLoaderException.cs
+++ b/PV260_Project/BusinessLayer/Exceptions/DataLoaderException.cs
@@ -1,4 +1,4 @@
-namespace BL.Exceptions;
+namespace BusinessLayer.Exceptions;
 
 [Serializable]
 public class DataLoaderException : Exception

--- a/PV260_Project/BusinessLayer/Exceptions/DataWriterException.cs
+++ b/PV260_Project/BusinessLayer/Exceptions/DataWriterException.cs
@@ -1,4 +1,4 @@
-namespace BL.Exceptions;
+namespace BusinessLayer.Exceptions;
 
 [Serializable]
 public class DataWriterException : Exception

--- a/PV260_Project/BusinessLayer/Extensions/CsvParsingExtensions.cs
+++ b/PV260_Project/BusinessLayer/Extensions/CsvParsingExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Globalization;
 
-namespace BL.Extensions
+namespace BusinessLayer.Extensions
 {
     public static class CsvParsingExtensions
     {

--- a/PV260_Project/BusinessLayer/Logging/ConsoleLogger.cs
+++ b/PV260_Project/BusinessLayer/Logging/ConsoleLogger.cs
@@ -1,4 +1,4 @@
-namespace BL.Logging;
+namespace BusinessLayer.Logging;
 
 public class ConsoleLogger : ILogger
 {

--- a/PV260_Project/BusinessLayer/Logging/ILogger.cs
+++ b/PV260_Project/BusinessLayer/Logging/ILogger.cs
@@ -1,4 +1,4 @@
-namespace BL.Logging;
+namespace BusinessLayer.Logging;
 
 public interface ILogger
 {

--- a/PV260_Project/BusinessLayer/Writers/ConsoleResultWriter.cs
+++ b/PV260_Project/BusinessLayer/Writers/ConsoleResultWriter.cs
@@ -1,7 +1,7 @@
 ﻿using System.Globalization;
-using DAL.Models;
+using DataLayer.Models;
 
-namespace BL.Writers
+namespace BusinessLayer.Writers
 {
     public class ConsoleResultWriter : IResultWriter
     {

--- a/PV260_Project/BusinessLayer/Writers/DiffStringGenerator.cs
+++ b/PV260_Project/BusinessLayer/Writers/DiffStringGenerator.cs
@@ -1,12 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using DAL.Models;
+﻿using System.Globalization;
+using DataLayer.Models;
 
-namespace BL.Writers
+namespace BusinessLayer.Writers
 {
     public static class DiffStringGenerator
     {

--- a/PV260_Project/BusinessLayer/Writers/FileResultWriter.cs
+++ b/PV260_Project/BusinessLayer/Writers/FileResultWriter.cs
@@ -4,10 +4,10 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using BL.Exceptions;
-using DAL.Models;
+using BusinessLayer.Exceptions;
+using DataLayer.Models;
 
-namespace BL.Writers
+namespace BusinessLayer.Writers
 {
     public class FileResultWriter : IResultWriter
     {

--- a/PV260_Project/BusinessLayer/Writers/IResultWriter.cs
+++ b/PV260_Project/BusinessLayer/Writers/IResultWriter.cs
@@ -1,6 +1,6 @@
-using DAL.Models;
+using DataLayer.Models;
 
-namespace BL.Writers;
+namespace BusinessLayer.Writers;
 
 public interface IResultWriter
 {

--- a/PV260_Project/DataLayer/DataLayer.csproj
+++ b/PV260_Project/DataLayer/DataLayer.csproj
@@ -4,7 +4,6 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <RootNamespace>DAL</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/PV260_Project/DataLayer/Models/DataSet.cs
+++ b/PV260_Project/DataLayer/Models/DataSet.cs
@@ -1,4 +1,4 @@
-﻿namespace DAL.Models
+﻿namespace DataLayer.Models
 {
     /// <summary>
     /// Represents a data item, which is downloaded at https://ark-funds.com/funds/arkk/

--- a/PV260_Project/DataLayer/Models/Holding.cs
+++ b/PV260_Project/DataLayer/Models/Holding.cs
@@ -1,4 +1,4 @@
-﻿namespace DAL.Models
+﻿namespace DataLayer.Models
 {
     /// <summary>
     /// Represents single line of holding in csv file

--- a/PV260_Project/DataLayer/Models/HoldingBaseInformation.cs
+++ b/PV260_Project/DataLayer/Models/HoldingBaseInformation.cs
@@ -1,4 +1,4 @@
-﻿namespace DAL.Models
+﻿namespace DataLayer.Models
 {
     /// <summary>
     /// These are the data, which do not change in time (at least I think)

--- a/PV260_Project/DataLayer/Models/HoldingChanges.cs
+++ b/PV260_Project/DataLayer/Models/HoldingChanges.cs
@@ -1,6 +1,6 @@
 ﻿using System.Globalization;
 
-namespace DAL.Models
+namespace DataLayer.Models
 {
     public class HoldingChanges
     {

--- a/PV260_Project/PresentationLayer/ConsoleApps/ConsoleApp.cs
+++ b/PV260_Project/PresentationLayer/ConsoleApps/ConsoleApp.cs
@@ -1,12 +1,12 @@
 using System.Globalization;
-using BL.DataLoading;
-using BL.DiffComputing;
-using BL.Exceptions;
-using BL.Logging;
-using BL.Writers;
+using BusinessLayer.DataLoading;
+using BusinessLayer.DiffComputing;
+using BusinessLayer.Exceptions;
+using BusinessLayer.Logging;
+using BusinessLayer.Writers;
 using CommandLine;
 
-namespace PL.ConsoleApps
+namespace PresentationLayer.ConsoleApps
 {
     public class ConsoleApp : IApp
     {

--- a/PV260_Project/PresentationLayer/ConsoleApps/Options.cs
+++ b/PV260_Project/PresentationLayer/ConsoleApps/Options.cs
@@ -1,6 +1,6 @@
 using CommandLine;
 
-namespace PL.ConsoleApps
+namespace PresentationLayer.ConsoleApps
 {
     /// <summary>
     /// Class used by CommandLineParser for parsing command line arguments

--- a/PV260_Project/PresentationLayer/IApp.cs
+++ b/PV260_Project/PresentationLayer/IApp.cs
@@ -1,4 +1,4 @@
-namespace PL;
+namespace PresentationLayer;
 
 public interface IApp
 {

--- a/PV260_Project/PresentationLayer/PresentationLayer.csproj
+++ b/PV260_Project/PresentationLayer/PresentationLayer.csproj
@@ -5,7 +5,6 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <RootNamespace>PL</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/PV260_Project/PresentationLayer/Program.cs
+++ b/PV260_Project/PresentationLayer/Program.cs
@@ -1,6 +1,6 @@
-using PL.ConsoleApps;
+using PresentationLayer.ConsoleApps;
 
-namespace PL
+namespace PresentationLayer
 {
     public class Program
     {

--- a/PV260_Project/Tests/BLTests/CsvFileLoaderTests.cs
+++ b/PV260_Project/Tests/BLTests/CsvFileLoaderTests.cs
@@ -1,6 +1,6 @@
 using System;
-using BL.DataLoading;
-using DAL.Models;
+using BusinessLayer.DataLoading;
+using DataLayer.Models;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/PV260_Project/Tests/BLTests/CsvParsingExtensionTests.cs
+++ b/PV260_Project/Tests/BLTests/CsvParsingExtensionTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
-using BL.Extensions;
-using DAL.Models;
+using BusinessLayer.Extensions;
+using DataLayer.Models;
 using NUnit.Framework;
 
 namespace Tests.BLTests;

--- a/PV260_Project/Tests/BLTests/DiffComputerTests.cs
+++ b/PV260_Project/Tests/BLTests/DiffComputerTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using BL.DiffComputing;
-using DAL.Models;
+using BusinessLayer.DiffComputing;
+using DataLayer.Models;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/PV260_Project/Tests/BLTests/ResultWriterTests.cs
+++ b/PV260_Project/Tests/BLTests/ResultWriterTests.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
-using BL.DataLoading;
-using BL.Writers;
-using DAL.Models;
+using BusinessLayer.DataLoading;
+using BusinessLayer.Writers;
+using DataLayer.Models;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/PV260_Project/Tests/UnitTest1.cs
+++ b/PV260_Project/Tests/UnitTest1.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO.Enumeration;
 using System.Reflection;
 using System.Runtime.InteropServices.ComTypes;
-using BL.DataLoading;
+using BusinessLayer.DataLoading;
 using FluentAssertions;
 using NUnit.Framework;
 


### PR DESCRIPTION
There was a need to change XML files in order to get rid of RIDER warnings